### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rbheda18/a5bcf338-9514-4ee5-9ba2-972ab809abff/21e5f0d1-2ab4-4610-89dd-cd1eb828660c/_apis/work/boardbadge/6810aa48-4f80-47fc-8856-3ef31b2505d3)](https://dev.azure.com/rbheda18/a5bcf338-9514-4ee5-9ba2-972ab809abff/_boards/board/t/21e5f0d1-2ab4-4610-89dd-cd1eb828660c/Microsoft.RequirementCategory)
 # AzureBoardsDemo
 
 This is a Simple repository for integration with Azure Boards.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#173](https://dev.azure.com/rbheda18/a5bcf338-9514-4ee5-9ba2-972ab809abff/_workitems/edit/173). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.